### PR TITLE
.ctaContainer remove a:active

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -341,8 +341,7 @@ header {
   -moz-appearance: none;
 }
 
-.ctaContainer a:hover,
-.ctaContainer a:focus {
+.ctaContainer a:hover {
   background: yellow;
   color: black;
 }


### PR DESCRIPTION
now the button will not remain highlighted when the popover modal window is closed